### PR TITLE
Fixed two typos.

### DIFF
--- a/lessons/cursor_navigation.html
+++ b/lessons/cursor_navigation.html
@@ -71,7 +71,7 @@ four five six
 seven eight nine
 ten eleven twelve
 thirteen fourteen fifteen
-sixteen seventeen eightteen
+sixteen seventeen eighteen
 nineteen twenty`,
 		startingScore: 2000,
 		expectedChanges: 25,

--- a/lessons/special_characters.html
+++ b/lessons/special_characters.html
@@ -41,7 +41,7 @@
 					Now there are a number of miscelanious signs that I couldn't really fit in a category, so I'll just list them out here.
 
 					= <span class="text-emphasis">equals</span>, _ <span class="text-emphasis">down score</span>, - <span class="text-emphasis">minus</span>, + <span class="text-emphasis">plus</span>, * <span class="text-emphasis">star</span>,
-					# <span class="text-emphasis">pound</span>, / <span class="text-emphasis">slash</span>, \ <span class="text-emphasis">back slash</span>, $ <span class="text-emphasis">dollar</span>, % <span class="text-emphasis">percent</span>, ^ <span class="text-emphasis">caret</span>,
+					# <span class="text-emphasis">hash</span>, / <span class="text-emphasis">slash</span>, \ <span class="text-emphasis">back slash</span>, $ <span class="text-emphasis">dollar</span>, % <span class="text-emphasis">percent</span>, ^ <span class="text-emphasis">caret</span>,
 					& <span class="text-emphasis">and sign</span>, | <span class="text-emphasis">pipe</span>, @ <span class="text-emphasis">at sign</span> and ~ for <span class="text-emphasis">tilde</span>.
 
 				</p>


### PR DESCRIPTION
There were two typos:

The special_characters.html page has a typo for the # symbol. It is called hash, not pound as the pound command issues the British currency symbol.

The cursor_navigation.html page has a typo in the "goal" section.